### PR TITLE
Fixes pip 10 incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+from pip._internal.req import parse_requirements
 import re, ast
 
 # get version from __version__ variable in fedex_integration/__init__.py


### PR DESCRIPTION
pip 10 does not support pip.re as
https://discuss.erpnext.com/t/bench-install-on-easy-setup-failing-no-pip-req/35823/3